### PR TITLE
Fix wrong config.php path if there is no WEBROOT

### DIFF
--- a/rtorrent-rutorrent/rootfs/usr/local/bin/startup
+++ b/rtorrent-rutorrent/rootfs/usr/local/bin/startup
@@ -14,7 +14,7 @@ if [ $WEBROOT != "/" ]; then
 else
     sed -i 's|<webroot>|/|g' /etc/nginx/nginx.conf
     sed -i 's|<folder>|/torrent|g' /etc/nginx/nginx.conf
-    sed -i 's|<webroot>|/|g' /var/www/html${WEBROOT}/conf/config.php
+    sed -i 's|<webroot>|/|g' /var/www/html/torrent/conf/config.php
 fi
 sed -i 's|<PORT_RTORRENT>|'$PORT_RTORRENT'|g' /home/torrent/.rtorrent.rc
 


### PR DESCRIPTION
My bad, I didn't see this mistake.

That should fix the wrong sed command when users don't have WEBROOT value.