### PR TITLE
Update executable path on entrypoint

### DIFF
--- a/rtorrent/Dockerfile
+++ b/rtorrent/Dockerfile
@@ -82,5 +82,5 @@ VOLUME /data /var/www/torrent/share/
 EXPOSE 8080
 RUN chmod +x /usr/local/bin/startup
 
-ENTRYPOINT ["/usr/bin/startup"]
+ENTRYPOINT ["/usr/local/bin/startup"]
 CMD ["rtorrent"]


### PR DESCRIPTION
The entrypoint doesn't work, it send an error : "/usr/bin/startup not found" and startup file located on /usr/local/bin ;)