### PR TITLE
# Update Dockerfile | add TERM variable

### DIFF
--- a/rtorrent/Dockerfile
+++ b/rtorrent/Dockerfile
@@ -8,8 +8,9 @@ ARG LIBTORRENT_VER=0.13.6
 ENV UID=991 \
     GID=991 \
     PORT_RTORRENT=45000 \
-    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
+    TERM=xterm
+    
 LABEL Description="rtorrent based on alpine" \
       tags="latest" \
       build_ver="2016111501"


### PR DESCRIPTION
Based on my own issues ( https://github.com/xataz/dockerfiles/issues/19 ) I search why have an error, and I found : so I add `TERM=xterm` ENV but I don't know what is this :x