### PR TITLE
Add uid and gid support to users.conf

### DIFF
--- a/samba/README.md
+++ b/samba/README.md
@@ -25,16 +25,16 @@ docker build -t xataz/samba github.com/xataz/dockerfiles.git#master:samba
 #### users.conf
 users.conf is a configuration file for list your users and them password :
 ```shell
-#USER:PASSWORD
-xataz:xatazpasswd
-user1:user1passwd
+#USER:PASSWORD:UID:GID
+xataz:xatazpasswd:2000:2000
+user1:user1passwd:2001:2001
 etc ...
 ```
 
 You can use environment variable CRYPT, for use users.conf with encrypt password :
 ```shell
-xataz:FAC84832FFCB741F13C5758E1319F46A
-user1:F5C8257B666CB899CC34AA3FF3771316
+xataz:FAC84832FFCB741F13C5758E1319F46A:2000:2000
+user1:F5C8257B666CB899CC34AA3FF3771316:2001:2001
 ```
 for encrypt your password on samba's format, use this command :
 ```shell

--- a/samba/rootfs/usr/local/bin/startup
+++ b/samba/rootfs/usr/local/bin/startup
@@ -6,8 +6,18 @@ if [ -e /config/shares.conf ] && [ -e /config/users.conf ]; then
         for line in $(cat /config/users.conf); do
             USERNAME=$(echo $line | cut -d: -f1)
             PASSWORD=$(echo $line | cut -d: -f2)
+            UID=$(echo $line | cut -d: -f3)
+            GID=$(echo $line | cut -d: -f4)
+            UIDCMD=""
+            GIDCMD=""
+            if [ ! -z $UID ]; then
+                UIDCMD="-u $UID"
+            fi
+            if [ ! -z $GID ]; then
+                GIDCMD="-g $GID"
+            fi
             echo "Add user $USERNAME"
-            adduser -D $USERNAME
+            adduser -D $USERNAME $UIDCMD $GIDCMD
             touch /var/lib/samba/private/smbpasswd
             (echo $PASSWORD;echo $PASSWORD) | smbpasswd -s -a $USERNAME
         done
@@ -18,8 +28,18 @@ if [ -e /config/shares.conf ] && [ -e /config/users.conf ]; then
             # <user>:<uid>:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:<passwd>:[U          ]:LCT-<date>:
             USERNAME=$(echo $line | cut -d: -f1)
             PASSWORD=$(echo $line | cut -d: -f2)
+            UID=$(echo $line | cut -d: -f3)
+            GID=$(echo $line | cut -d: -f4)
+            UIDCMD=""
+            GIDCMD=""
+            if [ ! -z $UID ]; then
+                UIDCMD="-u $UID"
+            fi
+            if [ ! -z $GID ]; then
+                GIDCMD="-g $GID"
+            fi
             echo "Add user $USERNAME"
-            adduser -D $USERNAME
+            adduser -D $USERNAME $UIDCMD $GIDCMD
             DATE=$(echo "obase=16;$(date +%s)" | bc)
             UID_USER=$(grep ${USERNAME} /etc/passwd | cut -d: -f3)
             sed 's|<user>|'${USERNAME}'|;s|<uid>|'${UID_USER}'|;s|<passwd>|'${PASSWORD}'|;s|<date>|'${DATE}'|' /templates/smbpasswd.tmpl >> /var/lib/samba/private/smbpasswd


### PR DESCRIPTION
This will add uid and gid support to users.conf while keeping backwards compatibility.

Fixes #36 